### PR TITLE
feat: automate test dev setup with Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@
 hello-http
 
 # OS files
-.DS_Store
+.DS_Store.ssh/
+.ssh/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,153 @@
+# hetzner-unikernels — Makefile
+#
+# Prerequisites (minimal):
+#   - hcloud CLI
+#   HCLOUD_TOKEN env var (Hetzner Cloud API token)
+#
+# Quick start:
+#   make check                   — verify prerequisites
+#   make 00-ops-nginx-qemu       — example 0: VM + ops + nginx unikernel in QEMU
+#   make 00-ops-nginx-qemu-destroy — destroy example 0
+#   make 00-kraft-nginx-qemu    — example 1: VM + kraftkit + nginx unikernel in QEMU (TCG)
+#   make 00-kraft-nginx-qemu-destroy — destroy example 1
+#   make servers                — list running servers
+
+# ── Configuration ──────────────────────────────────────────────
+
+SERVER_TYPE ?= cpx22
+LOCATION    ?= fsn1
+BASE_IMAGE  ?= ubuntu-24.04
+SSH_KEY_NAME := unikernels-key
+SSH_KEY_PATH := .ssh/id_ed25519
+
+# ── Colors ─────────────────────────────────────────────────────
+
+RESET  := \033[0m
+BOLD   := \033[1m
+RED    := \033[31m
+GREEN  := \033[32m
+YELLOW := \033[33m
+CYAN   := \033[36m
+
+# ── Prerequisite checks ────────────────────────────────────────
+
+.PHONY: check check-hcloud check-token setup-ssh
+
+check: check-hcloud check-token setup-ssh
+	@echo "$(GREEN)$(BOLD)All prerequisites met!$(RESET)"
+
+setup-ssh:
+	@if [ ! -f $(SSH_KEY_PATH) ]; then \
+		echo "$(CYAN)Generating SSH key $(SSH_KEY_PATH)...$(RESET)"; \
+		mkdir -p .ssh; \
+		ssh-keygen -t ed25519 -f $(SSH_KEY_PATH) -N ""; \
+	fi
+	@if ! hcloud ssh-key list | grep -q $(SSH_KEY_NAME); then \
+		echo "$(CYAN)Uploading SSH key $(SSH_KEY_NAME) to Hetzner...$(RESET)"; \
+		PUB_KEY=$$(cat $(SSH_KEY_PATH).pub); \
+		hcloud ssh-key create --name $(SSH_KEY_NAME) --public-key="$$PUB_KEY"; \
+	fi
+	@echo "$(GREEN)SSH key ready$(RESET)"
+
+check-hcloud:
+	@which hcloud >/dev/null 2>&1 || { \
+		echo "$(RED)$(BOLD)hcloud CLI not found.$(RESET)"; \
+		echo ""; \
+		echo "Install with:"; \
+		echo "  curl -sSLO https://github.com/hetznercloud/cli/releases/latest/download/hcloud-linux-amd64.tar.gz"; \
+		echo "  sudo tar -C /usr/local/bin --no-same-owner -xzf hcloud-linux-amd64.tar.gz hcloud"; \
+		echo "  rm hcloud-linux-amd64.tar.gz"; \
+		echo ""; \
+		echo "Or see: https://github.com/hetznercloud/cli/blob/main/docs/tutorials/setup-hcloud-cli.md"; \
+		exit 1; }
+	@echo "$(CYAN)hcloud$(RESET) found"
+
+check-token:
+	@if [ -z "$$HCLOUD_TOKEN" ]; then \
+		if ! hcloud context list 2>/dev/null | grep -q 'ACTIVE'; then \
+			echo "$(RED)$(BOLD)HCLOUD_TOKEN not set and no active hcloud context.$(RESET)"; \
+			echo ""; \
+			echo "Set it with:"; \
+			echo "  export HCLOUD_TOKEN=\"<your-hetzner-api-token>\""; \
+			echo ""; \
+			echo "Or create a context:"; \
+			echo "  hcloud context create <project-name>"; \
+			echo ""; \
+			echo "Get a token: https://console.hetzner.cloud/ → Security → API Tokens"; \
+			exit 1; \
+		fi; \
+	fi
+	@hcloud server list >/dev/null 2>&1 || { \
+		echo "$(RED)$(BOLD)hcloud cannot reach the API — check your token.$(RESET)"; \
+		exit 1; }
+	@echo "$(GREEN)Hetzner API reachable$(RESET)"
+
+# ── Example 00a: Nanos nginx in QEMU ──────────────────────
+
+.PHONY: 00-ops-nginx-qemu 00-ops-nginx-qemu-destroy 00-ops-nginx-qemu-ip
+
+SSH_KEY ?= unikernels-key
+
+00-ops-nginx-qemu: check
+	@echo "$(BOLD)Creating ops-nginx-qemu server with cloud-init...$(RESET)"
+	hcloud server create \
+		--name ops-nginx-qemu \
+		--type $(SERVER_TYPE) \
+		--image $(BASE_IMAGE) \
+		--location $(LOCATION) \
+		--user-data-from-file examples/00-ops-nginx-qemu/cloud-init.yaml \
+		--ssh-key $(SSH_KEY) \
+		--label example=00-ops-nginx-qemu
+	@echo ""
+	@echo "$(GREEN)$(BOLD)ops-nginx-qemu deployed!$(RESET)"
+	@echo "Cloud-init is installing ops and booting the unikernel (~2-3 min)."
+	@echo "Test with:  make 00-ops-nginx-qemu-ip && curl http://$$(make -s 00-ops-nginx-qemu-ip):8083"
+	@echo "SSH:  hcloud server ssh ops-nginx-qemu"
+
+00-ops-nginx-qemu-ip:
+	@hcloud server list -o columns=ipv4 -l example=00-ops-nginx-qemu | tail -1 | tr -d ' '
+
+00-ops-nginx-qemu-destroy: check
+	@echo "$(BOLD)Destroying ops-nginx-qemu...$(RESET)"
+	hcloud server delete ops-nginx-qemu
+	@echo "$(GREEN)Done.$(RESET)"
+
+# ── Example 01: Kraftkit nginx in QEMU (TCG) ──────────────────
+
+.PHONY: 00-kraft-nginx-qemu 00-kraft-nginx-qemu-destroy 00-kraft-nginx-qemu-ip
+
+00-kraft-nginx-qemu: check
+	@echo "$(BOLD)Creating kraft-nginx-qemu server with cloud-init...$(RESET)"
+	hcloud server create \
+		--name kraft-nginx-qemu \
+		--type $(SERVER_TYPE) \
+		--image $(BASE_IMAGE) \
+		--location $(LOCATION) \
+		--user-data-from-file examples/00-kraft-nginx-qemu/cloud-init.yaml \
+		--ssh-key $(SSH_KEY) \
+		--label example=00-kraft-nginx-qemu
+	@echo ""
+	@echo "$(GREEN)$(BOLD)kraft-nginx-qemu deployed!$(RESET)"
+	@echo "Cloud-init is installing kraftkit and booting the unikernel (~2-3 min)."
+	@echo "Test with:  make 00-kraft-nginx-qemu-ip && curl http://$$(make -s 00-kraft-nginx-qemu-ip):8080"
+	@echo "SSH:  hcloud server ssh kraft-nginx-qemu"
+
+00-kraft-nginx-qemu-ip:
+	@hcloud server list -o columns=ipv4 -l example=00-kraft-nginx-qemu | tail -1 | tr -d ' '
+
+
+00-kraft-nginx-qemu-destroy: check
+	@echo "$(BOLD)Destroying kraft-nginx-qemu...$(RESET)"
+	hcloud server delete kraft-nginx-qemu
+	@echo "$(GREEN)Done.$(RESET)"
+
+
+# ── Utility ──────────────────────────────────────────────────
+
+.PHONY: servers clean
+
+servers: check
+	@hcloud server list -o columns=id,name,status,ipv4,location,age
+
+clean:
+	@echo "Nothing to clean (builds happen on remote servers)."

--- a/README.md
+++ b/README.md
@@ -22,14 +22,41 @@ Unikernels aren't for everything. Debugging is harder, the ecosystem is smaller,
 
 | Runtime | Language | Hetzner Cloud VMs | Hetzner Dedicated | Notes |
 |---|---|---|---|---|
-| [Nanos / OPS](https://ops.city) | Go, Node, Python, Rust, C… | ✅ Native (object storage + cloud-init) | ✅ KVM | First-class Hetzner support via `ops` CLI |
-| [Unikraft](https://unikraft.org) | C, C++, Rust, Go, Python… | ⚠️ Custom boot setup required | ✅ KVM | No nested virt on cloud VMs; works on dedicated |
+| [Nanos](https://ops.city) | Go, Node, Python, Rust, C… | ✅ QEMU / Native | ✅ KVM | Fast deploy via `ops` CLI |
+| [Unikraft](https://unikraft.org) | C, C++, Rust, Go, Python… | ✅ QEMU (TCG) | ✅ KVM | Not a native deployment target |
 
-> **Hetzner Cloud VMs** don't support nested virtualization. OPS works around this with a cloud-init + `dd` approach — boot a generic Ubuntu VM, write the unikernel image directly to disk, and reboot into it. Other runtimes can use the same technique but need manual setup.
+> **Hetzner Cloud VMs** don't support nested virtualization. To run unikernels on these VMs, both Nanos and Unikraft must be wrapped in QEMU using TCG (Tiny Code Generator) emulation. This bypasses the host's lack of KVM capabilities and allows the unikernel kernels to boot.
+
+## Quick Start
+
+```bash
+# 1. Verify prerequisites
+make check
+
+# 2. Deploy example 00 — Nanos nginx in QEMU
+make 00-ops-nginx-qemu
+
+# 3. Get the IP and test
+make 00-ops-nginx-qemu-ip
+curl http://<IP>:8083
+
+# 4. Clean up
+make 00-ops-nginx-qemu-destroy
+```
+
+### Prerequisites
+
+- **hcloud CLI** — [Install guide](https://github.com/hetznercloud/cli/blob/main/docs/tutorials/setup-hcloud-cli.md)
+- **HCLOUD_TOKEN** — `export HCLOUD_TOKEN="<your-token>"` or `hcloud context create <name>`
+
+No local ops installation needed — the unikernel is built on the remote server via cloud-init.
 
 ## Examples
 
-See the [`examples/`](examples/) directory for ready-to-deploy unikernel examples.
+| # | Example | Description |
+|---|---|---|
+| 00a | [`00-ops-nginx-qemu`](examples/00-ops-nginx-qemu/) | Nanos nginx unikernel in QEMU on a Hetzner VM |
+| 00b | [`00-kraft-nginx-qemu`](examples/00-kraft-nginx-qemu/) | Unikraft nginx unikernel in QEMU (TCG) on a Hetzner VM |
 
 ## License
 

--- a/examples/00-kraft-nginx-qemu/cloud-init.yaml
+++ b/examples/00-kraft-nginx-qemu/cloud-init.yaml
@@ -1,0 +1,52 @@
+#cloud-config
+
+package_update: true
+packages:
+  - qemu-system-x86
+  - curl
+  - gnupg
+
+write_files:
+  - path: /root/setup-kraftkit.sh
+    content: |
+      #!/bin/bash
+      set -e
+
+      echo "[kraftkit] adding apt repo..."
+      mkdir -p /etc/apt/keyrings
+      curl -fsSL https://deb.pkg.kraftkit.sh/gpg.key | gpg --dearmor -o /etc/apt/keyrings/kraftkit.gpg --yes
+      echo 'deb [arch=amd64 signed-by=/etc/apt/keyrings/kraftkit.gpg] https://deb.pkg.kraftkit.sh /' > /etc/apt/sources.list.d/kraftkit.list
+
+      echo "[kraftkit] updating apt..."
+      apt-get update
+
+      echo "[kraftkit] installing kraftkit..."
+      apt-get install -y --no-install-recommends kraftkit
+
+      echo "[kraftkit] verifying..."
+      kraft version
+
+      echo "[kraftkit] running nginx unikernel..."
+      export HOME=/root
+      export PATH="/usr/sbin:/usr/bin:$PATH"
+      kraft run --detach -n nginx -p 8080:80 -M 256Mi --plat qemu --arch x86_64 --disable-acceleration unikraft.org/nginx:1.25
+
+      echo "[kraftkit] waiting for nginx..."
+      for i in $(seq 1 30); do
+        if curl -s --max-time 2 http://localhost:8080 >/dev/null 2>&1; then
+          echo "[kraftkit] nginx is up on port 8080"
+          break
+        fi
+        sleep 2
+      done
+
+      echo "[kraftkit] setting up iptables port 80 -> 8080..."
+      iptables -t nat -A PREROUTING -p tcp --dport 80 -j REDIRECT --to-port 8080
+      iptables -t nat -A OUTPUT -p tcp --dport 80 -j REDIRECT --to-port 8080
+
+      echo "[kraftkit] done — nginx reachable on port 80 and 8080"
+    owner: root:root
+    permissions: '0755'
+
+runcmd:
+  - /root/setup-kraftkit.sh 2>&1 | tee /root/kraftkit.log

--- a/examples/00-ops-nginx-qemu/README.md
+++ b/examples/00-ops-nginx-qemu/README.md
@@ -1,0 +1,46 @@
+# Example 00a — OPS/Nanos Nginx in QEMU
+
+Spin up a Hetzner Cloud VM, install [OPS](https://ops.city), and run the prebuilt nginx 1.18.0 unikernel inside QEMU.
+
+## What happens
+
+1. `hcloud` creates a cpx22 VM with cloud-init
+2. Cloud-init installs `qemu-system-x86` and `ops`
+3. `ops pkg load` downloads the `eyberg/nginx:1.18.0` package and boots it in QEMU
+4. Nginx listens on port **8083** inside the VM
+5. iptables redirects port 80 → 8083 for easy public access
+
+## Deploy
+
+```bash
+make 00-ops-nginx-qemu
+```
+
+## Test
+
+```bash
+make 00-ops-nginx-qemu-ip    # print the VM IP
+curl http://<IP>:8083
+curl http://<IP>:80
+```
+
+Expected: `Hello from Nanos!`
+
+## SSH
+
+```bash
+hcloud server ssh ops-nginx-qemu
+ps aux | grep qemu          # the unikernel is a QEMU process
+```
+
+## Destroy
+
+```bash
+make 00-ops-nginx-qemu-destroy
+```
+
+## Notes
+
+- The prebuilt `eyberg/nginx:1.18.0` package listens on **8083** (http) and **8084** (https)
+- OPS installs to `/.ops` when $HOME is `/` (cloud-init context)
+- No custom image build needed — this is the fastest way to get a unikernel running

--- a/examples/00-ops-nginx-qemu/cloud-init.yaml
+++ b/examples/00-ops-nginx-qemu/cloud-init.yaml
@@ -1,0 +1,55 @@
+#cloud-config
+
+package_update: true
+packages:
+  - qemu-system-x86
+  - curl
+
+write_files:
+  - path: /root/run-nginx-unikernel.sh
+    content: |
+      #!/bin/bash
+      set -x
+
+      echo "[ops] installing ops..."
+      curl https://ops.city/get.sh -sSL | sh || true
+
+      # ops installs to $HOME/.ops/bin — find it
+      for candidate in /root/.ops/bin/ops /.ops/bin/ops; do
+        if [ -x "$candidate" ]; then
+          export PATH="$(dirname "$candidate"):$PATH"
+          echo "[ops] found ops at: $candidate"
+          break
+        fi
+      done
+
+      if ! command -v ops >/dev/null 2>&1; then
+        echo "[ops] ERROR: ops binary not found"
+        exit 1
+      fi
+
+      echo "[ops] pulling nginx 1.18.0 package..."
+      ops pkg get eyberg/nginx:1.18.0
+
+      echo "[ops] running nginx unikernel (QEMU, port 8083)..."
+      ops pkg load eyberg/nginx:1.18.0 -p 8083 &
+
+      echo "[ops] waiting for nginx to start..."
+      for i in $(seq 1 30); do
+        if curl -s --max-time 2 http://localhost:8083 >/dev/null 2>&1; then
+          echo "[ops] nginx is up on port 8083"
+          break
+        fi
+        sleep 2
+      done
+
+      echo "[ops] setting up iptables to forward 80 -> 8083..."
+      iptables -t nat -A PREROUTING -p tcp --dport 80 -j REDIRECT --to-port 8083
+      iptables -t nat -A OUTPUT -p tcp --dport 80 -j REDIRECT --to-port 8083
+
+      echo "[ops] done — nginx reachable on port 80 and 8083"
+    owner: root:root
+    permissions: '0755'
+
+runcmd:
+  - /root/run-nginx-unikernel.sh 2>&1 | tee /root/run.log


### PR DESCRIPTION
Introduces a Makefile to automate the deployment and destruction of unikernel test servers on Hetzner Cloud, including self-healing SSH key management. Adds examples for both OPS and Kraftkit runtimes.

Closes #3