### PR TITLE
feat: add hello-world examples and build tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,6 @@
 *.img
 .ops/
 
-# Compiled binaries
-hello-http
-
 # OS files
 .DS_Store.ssh/
 .ssh/

--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,30 @@
 # hetzner-unikernels — Makefile
 #
-# Prerequisites (minimal):
+# Prerequisites:
 #   - hcloud CLI
-#   HCLOUD_TOKEN env var (Hetzner Cloud API token)
+#   - HCLOUD_TOKEN env var or active hcloud context
+#
+# Examples 00 and 03 share one server (rebuild, not delete+create).
+# Example 01 uses OPS native instance management.
 #
 # Quick start:
-#   make check                   — verify prerequisites
-#   make 00-ops-nginx-qemu       — example 0: VM + ops + nginx unikernel in QEMU
-#   make 00-ops-nginx-qemu-destroy — destroy example 0
-#   make 00-kraft-nginx-qemu    — example 1: VM + kraftkit + nginx unikernel in QEMU (TCG)
-#   make 00-kraft-nginx-qemu-destroy — destroy example 1
-#   make servers                — list running servers
+#   make check                — verify hcloud prerequisites
+#   make servers              — list running servers
+#   make 00-ops-nginx-qemu    — example 00a: ops + nginx in QEMU via cloud-init
+#   make 00-kraft-nginx-qemu  — example 00b: kraftkit + nginx in QEMU via cloud-init
+#   make 01-ops-hello-http    — example 01: native OPS deploy to Hetzner (ops image + instance)
+#   make 02-ops-hello-dd      — example 02: OPS image dd'd to disk, HTTP server on :8080
+#   make ip                   — print shared server IP (for 00 and 03)
+#   make ssh                  — SSH into shared server
+#   make destroy              — delete shared server (stop billing)
 
 # ── Configuration ──────────────────────────────────────────────
 
 SERVER_TYPE ?= cpx22
 LOCATION    ?= fsn1
 BASE_IMAGE  ?= ubuntu-24.04
-SSH_KEY_NAME := unikernels-key
-SSH_KEY_PATH := .ssh/id_ed25519
+SSH_KEY     ?= bb-podman-key
+SERVER      ?= unikernel-example
 
 # ── Colors ─────────────────────────────────────────────────────
 
@@ -26,28 +32,16 @@ RESET  := \033[0m
 BOLD   := \033[1m
 RED    := \033[31m
 GREEN  := \033[32m
-YELLOW := \033[33m
 CYAN   := \033[36m
 
 # ── Prerequisite checks ────────────────────────────────────────
 
-.PHONY: check check-hcloud check-token setup-ssh
+.PHONY: check check-hcloud check-token check-ops check-ops-storage
 
-check: check-hcloud check-token setup-ssh
+check: check-hcloud check-token
 	@echo "$(GREEN)$(BOLD)All prerequisites met!$(RESET)"
 
-setup-ssh:
-	@if [ ! -f $(SSH_KEY_PATH) ]; then \
-		echo "$(CYAN)Generating SSH key $(SSH_KEY_PATH)...$(RESET)"; \
-		mkdir -p .ssh; \
-		ssh-keygen -t ed25519 -f $(SSH_KEY_PATH) -N ""; \
-	fi
-	@if ! hcloud ssh-key list | grep -q $(SSH_KEY_NAME); then \
-		echo "$(CYAN)Uploading SSH key $(SSH_KEY_NAME) to Hetzner...$(RESET)"; \
-		PUB_KEY=$$(cat $(SSH_KEY_PATH).pub); \
-		hcloud ssh-key create --name $(SSH_KEY_NAME) --public-key="$$PUB_KEY"; \
-	fi
-	@echo "$(GREEN)SSH key ready$(RESET)"
+HCLOUD_MIN_VERSION := 1.62.0
 
 check-hcloud:
 	@which hcloud >/dev/null 2>&1 || { \
@@ -57,97 +51,217 @@ check-hcloud:
 		echo "  curl -sSLO https://github.com/hetznercloud/cli/releases/latest/download/hcloud-linux-amd64.tar.gz"; \
 		echo "  sudo tar -C /usr/local/bin --no-same-owner -xzf hcloud-linux-amd64.tar.gz hcloud"; \
 		echo "  rm hcloud-linux-amd64.tar.gz"; \
-		echo ""; \
-		echo "Or see: https://github.com/hetznercloud/cli/blob/main/docs/tutorials/setup-hcloud-cli.md"; \
 		exit 1; }
-	@echo "$(CYAN)hcloud$(RESET) found"
+	@VERS=$$(hcloud version 2>/dev/null | awk '{print $$2}'); \
+	 if [ -z "$$VERS" ] || printf '%s\n' "$(HCLOUD_MIN_VERSION)" "$$VERS" | sort -V | head -1 | grep -qv "$(HCLOUD_MIN_VERSION)"; then \
+		echo "$(RED)$(BOLD)hcloud >= $(HCLOUD_MIN_VERSION) required (found $$VERS).$(RESET)"; \
+		echo ""; \
+		echo "Update with:"; \
+		echo "  curl -sSLO https://github.com/hetznercloud/cli/releases/latest/download/hcloud-linux-amd64.tar.gz"; \
+		echo "  sudo tar -C /usr/local/bin --no-same-owner -xzf hcloud-linux-amd64.tar.gz hcloud"; \
+		echo "  rm hcloud-linux-amd64.tar.gz"; \
+		exit 1; \
+	 fi
+	@echo "$(CYAN)hcloud$(RESET) $$(hcloud version | awk '{print $$2}')"
 
 check-token:
 	@if [ -z "$$HCLOUD_TOKEN" ]; then \
 		if ! hcloud context list 2>/dev/null | grep -q 'ACTIVE'; then \
 			echo "$(RED)$(BOLD)HCLOUD_TOKEN not set and no active hcloud context.$(RESET)"; \
 			echo ""; \
-			echo "Set it with:"; \
 			echo "  export HCLOUD_TOKEN=\"<your-hetzner-api-token>\""; \
 			echo ""; \
-			echo "Or create a context:"; \
-			echo "  hcloud context create <project-name>"; \
-			echo ""; \
-			echo "Get a token: https://console.hetzner.cloud/ → Security → API Tokens"; \
+			echo "  Or create a context:  hcloud context create <project-name>"; \
+			echo "  Get a token: https://console.hetzner.cloud/ → Security → API Tokens"; \
 			exit 1; \
 		fi; \
 	fi
 	@hcloud server list >/dev/null 2>&1 || { \
 		echo "$(RED)$(BOLD)hcloud cannot reach the API — check your token.$(RESET)"; \
+		echo "  export HCLOUD_TOKEN=\"<your-hetzner-api-token>\""; \
 		exit 1; }
 	@echo "$(GREEN)Hetzner API reachable$(RESET)"
 
-# ── Example 00a: Nanos nginx in QEMU ──────────────────────
+check-ops:
+	@which ops >/dev/null 2>&1 || { \
+		echo "$(RED)$(BOLD)ops CLI not found.$(RESET)"; \
+		echo "Install: curl https://ops.city/get.sh | sh"; \
+		exit 1; }
+	@echo "$(CYAN)ops$(RESET) found"
 
-.PHONY: 00-ops-nginx-qemu 00-ops-nginx-qemu-destroy 00-ops-nginx-qemu-ip
+check-ops-storage:
+	@FAIL=0; \
+	 [ -n "$$HCLOUD_TOKEN" ] || { echo "  $(RED)HCLOUD_TOKEN$(RESET) not set"; FAIL=1; }; \
+	 [ -n "$$OBJECT_STORAGE_KEY" ] || { echo "  $(RED)OBJECT_STORAGE_KEY$(RESET) not set"; FAIL=1; }; \
+	 [ -n "$$OBJECT_STORAGE_SECRET" ] || { echo "  $(RED)OBJECT_STORAGE_SECRET$(RESET) not set"; FAIL=1; }; \
+	 BUCKET=$$(python3 -c "import json; print(json.load(open('examples/01-ops-hello-http/config.json'))['CloudConfig'].get('BucketName',''))" 2>/dev/null); \
+	 [ -n "$$BUCKET" ] || { echo "  $(RED)BucketName$(RESET) not set in examples/01-ops-hello-http/config.json"; FAIL=1; }; \
+	 [ $$FAIL -eq 0 ] || { \
+		echo ""; \
+		echo "$(BOLD)Example 01 requires OPS Hetzner credentials:$(RESET)"; \
+		echo ""; \
+		echo "  export HCLOUD_TOKEN=\"<your-hetzner-api-token>\""; \
+		echo "  export OBJECT_STORAGE_KEY=\"<your-storage-access-key>\""; \
+		echo "  export OBJECT_STORAGE_SECRET=\"<your-storage-secret-key>\""; \
+		echo "  export OBJECT_STORAGE_DOMAIN=\"...\"  (optional, default: your-objectstorage.com)"; \
+		echo ""; \
+		echo "  Set BucketName and Zone in examples/01-ops-hello-http/config.json"; \
+		echo ""; \
+		echo "  Get credentials: https://console.hetzner.cloud/ → Object Storage"; \
+		exit 1; }
+	@echo "$(CYAN)OPS storage credentials set$(RESET)"
 
-SSH_KEY ?= unikernels-key
+# ── Shared helpers (examples 00, 03) ───────────────────────────
+#
+# ensure-server CLOUD_INIT_FILE
+#   Create server if absent; rebuild with cloud-init if it exists.
+define ensure-server
+	@if hcloud server describe $(SERVER) >/dev/null 2>&1; then \
+		echo "$(BOLD)Rebuilding $(SERVER) with cloud-init...$(RESET)"; \
+		hcloud server rebuild $(SERVER) \
+			--image $(BASE_IMAGE) \
+			--user-data-from-file $(1); \
+	else \
+		echo "$(BOLD)Creating $(SERVER)...$(RESET)"; \
+		hcloud server create \
+			--name $(SERVER) \
+			--type $(SERVER_TYPE) \
+			--image $(BASE_IMAGE) \
+			--location $(LOCATION) \
+			--ssh-key $(SSH_KEY) \
+			--user-data-from-file $(1); \
+	fi
+endef
+
+# ensure-server-vanilla
+#   Create server if absent; rebuild to clean ubuntu (no cloud-init) if it exists.
+define ensure-server-vanilla
+	@if hcloud server describe $(SERVER) >/dev/null 2>&1; then \
+		echo "$(BOLD)Rebuilding $(SERVER) to vanilla $(BASE_IMAGE)...$(RESET)"; \
+		hcloud server rebuild $(SERVER) --image $(BASE_IMAGE); \
+	else \
+		echo "$(BOLD)Creating $(SERVER)...$(RESET)"; \
+		hcloud server create \
+			--name $(SERVER) \
+			--type $(SERVER_TYPE) \
+			--image $(BASE_IMAGE) \
+			--location $(LOCATION) \
+			--ssh-key $(SSH_KEY); \
+	fi
+endef
+
+# wait-ssh
+#   Clear stale known_hosts entry and poll until SSH is available.
+define wait-ssh
+	@set -e; \
+	 IP=$$(hcloud server describe $(SERVER) -o format='{{.PublicNet.IPv4.IP}}'); \
+	 ssh-keygen -R $$IP 2>/dev/null || true; \
+	 echo "$(BOLD)Waiting for SSH on $$IP...$(RESET)"; \
+	 until ssh -q -o StrictHostKeyChecking=no -o ConnectTimeout=5 root@$$IP exit 2>/dev/null; \
+	   do sleep 3; done
+endef
+
+# ── Example 00: OPS/Nanos nginx in QEMU via cloud-init ─────────
+
+.PHONY: 00-ops-nginx-qemu
 
 00-ops-nginx-qemu: check
-	@echo "$(BOLD)Creating ops-nginx-qemu server with cloud-init...$(RESET)"
-	hcloud server create \
-		--name ops-nginx-qemu \
-		--type $(SERVER_TYPE) \
-		--image $(BASE_IMAGE) \
-		--location $(LOCATION) \
-		--user-data-from-file examples/00-ops-nginx-qemu/cloud-init.yaml \
-		--ssh-key $(SSH_KEY) \
-		--label example=00-ops-nginx-qemu
+	$(call ensure-server,examples/00-ops-nginx-qemu/cloud-init.yaml)
 	@echo ""
-	@echo "$(GREEN)$(BOLD)ops-nginx-qemu deployed!$(RESET)"
+	@echo "$(GREEN)$(BOLD)$(SERVER) running 00-ops-nginx-qemu!$(RESET)"
 	@echo "Cloud-init is installing ops and booting the unikernel (~2-3 min)."
-	@echo "Test with:  make 00-ops-nginx-qemu-ip && curl http://$$(make -s 00-ops-nginx-qemu-ip):8083"
-	@echo "SSH:  hcloud server ssh ops-nginx-qemu"
+	@echo "  http://$$(make -s ip):8083"
+	@echo "SSH:  make ssh"
 
-00-ops-nginx-qemu-ip:
-	@hcloud server list -o columns=ipv4 -l example=00-ops-nginx-qemu | tail -1 | tr -d ' '
+# ── Example 00b: Kraftkit nginx in QEMU via cloud-init ─────────
 
-00-ops-nginx-qemu-destroy: check
-	@echo "$(BOLD)Destroying ops-nginx-qemu...$(RESET)"
-	hcloud server delete ops-nginx-qemu
-	@echo "$(GREEN)Done.$(RESET)"
-
-# ── Example 01: Kraftkit nginx in QEMU (TCG) ──────────────────
-
-.PHONY: 00-kraft-nginx-qemu 00-kraft-nginx-qemu-destroy 00-kraft-nginx-qemu-ip
+.PHONY: 00-kraft-nginx-qemu
 
 00-kraft-nginx-qemu: check
-	@echo "$(BOLD)Creating kraft-nginx-qemu server with cloud-init...$(RESET)"
-	hcloud server create \
-		--name kraft-nginx-qemu \
-		--type $(SERVER_TYPE) \
-		--image $(BASE_IMAGE) \
-		--location $(LOCATION) \
-		--user-data-from-file examples/00-kraft-nginx-qemu/cloud-init.yaml \
-		--ssh-key $(SSH_KEY) \
-		--label example=00-kraft-nginx-qemu
+	$(call ensure-server,examples/00-kraft-nginx-qemu/cloud-init.yaml)
 	@echo ""
-	@echo "$(GREEN)$(BOLD)kraft-nginx-qemu deployed!$(RESET)"
+	@echo "$(GREEN)$(BOLD)$(SERVER) running 00-kraft-nginx-qemu!$(RESET)"
 	@echo "Cloud-init is installing kraftkit and booting the unikernel (~2-3 min)."
-	@echo "Test with:  make 00-kraft-nginx-qemu-ip && curl http://$$(make -s 00-kraft-nginx-qemu-ip):8080"
-	@echo "SSH:  hcloud server ssh kraft-nginx-qemu"
+	@echo "Test with:  curl http://$$(make -s ip):8080"
+	@echo "SSH:        make ssh"
 
-00-kraft-nginx-qemu-ip:
-	@hcloud server list -o columns=ipv4 -l example=00-kraft-nginx-qemu | tail -1 | tr -d ' '
+# ── Example 01: OPS hello-http deployed natively to Hetzner ───
+#
+# Requires: HCLOUD_TOKEN, OBJECT_STORAGE_DOMAIN, OBJECT_STORAGE_KEY,
+#           OBJECT_STORAGE_SECRET, and BucketName set in config.json.
+#
+# Flow: ops image create → Hetzner snapshot → ops instance create
 
+.PHONY: 01-ops-hello-http 01-ops-hello-http-destroy
 
-00-kraft-nginx-qemu-destroy: check
-	@echo "$(BOLD)Destroying kraft-nginx-qemu...$(RESET)"
-	hcloud server delete kraft-nginx-qemu
+01-ops-hello-http: check check-ops check-ops-storage
+	@echo "$(BOLD)Building and uploading image to Hetzner...$(RESET)"
+	cd examples/01-ops-hello-http && go build -o hello-http main.go && ops image create -t hetzner -c config.json hello-http
+	@echo "$(BOLD)Creating Hetzner instance...$(RESET)"
+	-cd examples/01-ops-hello-http && ops instance delete ops-hello-http -t hetzner -c config.json 2>/dev/null
+	cd examples/01-ops-hello-http && ops instance create ops-hello-http -t hetzner -c config.json -p 8080
+	@echo ""
+	@echo "$(GREEN)$(BOLD)ops-hello-http instance running!$(RESET)"
+	@echo "List with: ops instance list -t hetzner -c examples/01-ops-hello-http/config.json"
+
+01-ops-hello-http-destroy: check-ops
+	@echo "$(BOLD)Deleting ops-hello-http instance and image...$(RESET)"
+	-cd examples/01-ops-hello-http && ops instance delete ops-hello-http -t hetzner -c config.json
+	-cd examples/01-ops-hello-http && ops image delete ops-hello-http -t hetzner -c config.json
 	@echo "$(GREEN)Done.$(RESET)"
 
+# ── Example 02: OPS hello-http dd'd to disk ───────────────────
 
-# ── Utility ──────────────────────────────────────────────────
+.PHONY: 02-ops-hello-dd
 
-.PHONY: servers clean
+02-ops-hello-dd: check
+	@echo "$(BOLD)Building ops-hello-dd image...$(RESET)"
+	$(MAKE) -C examples/02-ops-hello-dd image
+	$(call ensure-server-vanilla)
+	$(call wait-ssh)
+	@set -e; \
+	 test -f examples/02-ops-hello-dd/image/ops-hello-dd.img || { echo "Image not found — run make -C examples/02-ops-hello-dd image"; exit 1; }; \
+	 IP=$$(hcloud server describe $(SERVER) -o format='{{.PublicNet.IPv4.IP}}'); \
+	 echo "$(BOLD)Deploying image via dd...$(RESET)"; \
+	 echo "$(BOLD)Uploading image to server...$(RESET)"; \
+	 scp -o StrictHostKeyChecking=no \
+	     examples/02-ops-hello-dd/image/ops-hello-dd.img root@$$IP:/dev/shm/disk.img; \
+	 echo "$(BOLD)Writing image to disk...$(RESET)"; \
+	 ssh -o StrictHostKeyChecking=no \
+	     -o ServerAliveInterval=2 \
+	     -o ServerAliveCountMax=3 \
+	     root@$$IP \
+	   "cp /bin/dd /dev/shm/dd && \
+	    blkdiscard /dev/sda -f || true && \
+	    /dev/shm/dd if=/dev/shm/disk.img of=/dev/sda bs=4M conv=sync && \
+	    echo s > /proc/sysrq-trigger && echo o > /proc/sysrq-trigger" || true; \
+	 echo "$(BOLD)Waiting for server to power off...$(RESET)"; \
+	 until [ "$$(hcloud server describe $(SERVER) -o format='{{.Status}}')" = "off" ]; do sleep 3; done; \
+	 echo "$(BOLD)Powering on...$(RESET)"; \
+	 hcloud server poweron $(SERVER); \
+	 echo "$(BOLD)Waiting for port 8080...$(RESET)"; \
+	 until curl -sf --max-time 3 http://$$IP:8080 >/dev/null 2>&1; do sleep 3; done
+	@echo ""
+	@echo "$(GREEN)$(BOLD)$(SERVER) running 02-ops-hello-dd!$(RESET)"
+	@echo "Test with: make ip | xargs -I{} curl http://{}:8080"
+
+# ── Utility ────────────────────────────────────────────────────
+
+.PHONY: ip ssh destroy servers clean
+
+ip:
+	@hcloud server describe $(SERVER) -o format='{{.PublicNet.IPv4.IP}}'
+
+ssh: check
+	hcloud server ssh $(SERVER)
+
+destroy: check
+	@echo "$(BOLD)Destroying $(SERVER)...$(RESET)"
+	hcloud server delete $(SERVER)
+	@echo "$(GREEN)Done.$(RESET)"
 
 servers: check
 	@hcloud server list -o columns=id,name,status,ipv4,location,age
 
 clean:
-	@echo "Nothing to clean (builds happen on remote servers)."
+	$(MAKE) -C examples/02-ops-hello-dd clean

--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ Unikernels aren't for everything. Debugging is harder, the ecosystem is smaller,
 
 | Runtime | Language | Hetzner Cloud VMs | Hetzner Dedicated | Notes |
 |---|---|---|---|---|
-| [Nanos](https://ops.city) | Go, Node, Python, Rust, C… | ✅ QEMU / Native | ✅ KVM | Fast deploy via `ops` CLI |
-| [Unikraft](https://unikraft.org) | C, C++, Rust, Go, Python… | ✅ QEMU (TCG) | ✅ KVM | Not a native deployment target |
+| [Nanos / OPS](https://ops.city) | Go, Node, Python, Rust, C… | ✅ Native (object storage + cloud-init) | ✅ KVM | First-class Hetzner support via `ops` CLI |
+| [Unikraft](https://unikraft.org) | C, C++, Rust, Go, Python… | ⚠️ Custom boot setup required | ✅ KVM | No nested virt on cloud VMs; works on dedicated |
 
-> **Hetzner Cloud VMs** don't support nested virtualization. To run unikernels on these VMs, both Nanos and Unikraft must be wrapped in QEMU using TCG (Tiny Code Generator) emulation. This bypasses the host's lack of KVM capabilities and allows the unikernel kernels to boot.
+> **Hetzner Cloud VMs** don't support nested virtualization. OPS works around this with a cloud-init + `dd` approach — boot a generic Ubuntu VM, write the unikernel image directly to disk, and reboot into it. Other runtimes can use the same technique but need manual setup.
 
 ## Quick Start
 
@@ -33,30 +33,61 @@ Unikernels aren't for everything. Debugging is harder, the ecosystem is smaller,
 # 1. Verify prerequisites
 make check
 
-# 2. Deploy example 00 — Nanos nginx in QEMU
-make 00-ops-nginx-qemu
+# 2. Deploy an example
+make 00-ops-nginx-qemu     # nginx in QEMU via cloud-init
+make 02-ops-hello-dd        # Go HTTP server dd'd to disk
 
 # 3. Get the IP and test
-make 00-ops-nginx-qemu-ip
-curl http://<IP>:8083
+make ip
+curl http://$(make -s ip):8080
 
-# 4. Clean up
-make 00-ops-nginx-qemu-destroy
+# 4. SSH into the server (cloud-init examples only)
+make ssh
+
+# 5. Clean up
+make destroy
 ```
 
 ### Prerequisites
 
-- **hcloud CLI** — [Install guide](https://github.com/hetznercloud/cli/blob/main/docs/tutorials/setup-hcloud-cli.md)
+- **hcloud CLI** >= 1.62 — [Install guide](https://github.com/hetznercloud/cli/blob/main/docs/tutorials/setup-hcloud-cli.md)
 - **HCLOUD_TOKEN** — `export HCLOUD_TOKEN="<your-token>"` or `hcloud context create <name>`
+- **ops CLI** — `curl https://ops.city/get.sh | sh` (examples 01, 02)
 
-No local ops installation needed — the unikernel is built on the remote server via cloud-init.
+### Server reuse
+
+All examples share one Hetzner VM (`SERVER=unikernel-example`). First run creates it; subsequent runs rebuild it. This avoids hourly billing for multiple servers. Run `make destroy` when done.
 
 ## Examples
 
-| # | Example | Description |
-|---|---|---|
-| 00a | [`00-ops-nginx-qemu`](examples/00-ops-nginx-qemu/) | Nanos nginx unikernel in QEMU on a Hetzner VM |
-| 00b | [`00-kraft-nginx-qemu`](examples/00-kraft-nginx-qemu/) | Unikraft nginx unikernel in QEMU (TCG) on a Hetzner VM |
+| # | Target | Description | Requires |
+|---|---|---|---|
+| 00a | `make 00-ops-nginx-qemu` | OPS nginx in QEMU via cloud-init | hcloud |
+| 00b | `make 00-kraft-nginx-qemu` | Kraftkit nginx in QEMU via cloud-init | hcloud |
+| 01 | `make 01-ops-hello-http` | Native OPS deploy: snapshot + instance | hcloud, ops, object storage |
+| 02 | `make 02-ops-hello-dd` | OPS image dd'd to disk, HTTP server on :8080 | hcloud, ops |
+
+### Example 00a/00b: QEMU via cloud-init
+
+Spins up a Hetzner VM, installs OPS or Kraftkit via cloud-init, and runs a unikernel inside QEMU on the VM. No local tooling needed beyond `hcloud`.
+
+### Example 01: Native OPS deployment
+
+Uses `ops image create -t hetzner` to build the image, upload to Hetzner Object Storage, create a snapshot, and boot an instance from it. Requires object storage credentials:
+
+```bash
+export OBJECT_STORAGE_KEY="<your-key>"
+export OBJECT_STORAGE_SECRET="<your-secret>"
+```
+
+### Example 02: dd deployment (no object storage)
+
+Builds the OPS image locally with `ops build -t hetzner`, uploads it to the VM via `scp`, writes it to `/dev/sda` with `dd`, and power-cycles the server. No object storage needed — ideal for dev iteration.
+
+```bash
+make 02-ops-hello-dd
+curl http://$(make -s ip):8080
+```
 
 ## License
 

--- a/examples/01-ops-hello-http/.gitignore
+++ b/examples/01-ops-hello-http/.gitignore
@@ -1,0 +1,1 @@
+hello-http

--- a/examples/01-ops-hello-http/Makefile
+++ b/examples/01-ops-hello-http/Makefile
@@ -1,0 +1,20 @@
+IMAGE_NAME    := ops-hello-http
+INSTANCE_NAME := ops-hello-http
+
+.PHONY: image deploy destroy clean
+
+image:
+	go build -o hello-http main.go
+	ops image create -t hetzner -c config.json hello-http
+
+deploy: image
+	-ops instance delete $(INSTANCE_NAME) -t hetzner -c config.json
+	ops instance create $(IMAGE_NAME) -t hetzner -c config.json -p 8080
+
+destroy:
+	-ops instance delete $(INSTANCE_NAME) -t hetzner -c config.json
+	-ops image delete $(IMAGE_NAME) -t hetzner -c config.json
+
+clean:
+	-ops instance delete $(INSTANCE_NAME) -t hetzner -c config.json
+	-ops image delete $(IMAGE_NAME) -t hetzner -c config.json

--- a/examples/01-ops-hello-http/config.json
+++ b/examples/01-ops-hello-http/config.json
@@ -1,0 +1,14 @@
+{
+  "Uefi": true,
+  "CloudConfig": {
+    "BucketName": "unikernels",
+    "ImageName": "ops-hello-http",
+    "Flavor": "cpx22",
+    "Zone": "hel1"
+  },
+  "RunConfig": {
+    "ImageName": "ops-hello-http",
+    "InstanceName": "ops-hello-http",
+    "Ports": ["8080"]
+  }
+}

--- a/examples/01-ops-hello-http/main.go
+++ b/examples/01-ops-hello-http/main.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func main() {
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "Hello World from Nanos Unikernel!")
+	})
+	fmt.Println("Listening on :8080")
+	http.ListenAndServe(":8080", nil)
+}

--- a/examples/02-ops-hello-dd/.gitignore
+++ b/examples/02-ops-hello-dd/.gitignore
@@ -1,0 +1,2 @@
+image/
+hello-dd

--- a/examples/02-ops-hello-dd/Makefile
+++ b/examples/02-ops-hello-dd/Makefile
@@ -1,0 +1,20 @@
+IMAGE_NAME := ops-hello-dd
+IMAGE_SRC  := $(HOME)/.ops/images/$(IMAGE_NAME)
+IMAGE_OUT  := image/$(IMAGE_NAME).img
+
+.PHONY: build run image clean
+
+build:
+	go build -o hello-dd main.go
+	ops build -t hetzner hello-dd -c config.json
+
+run:
+	ops run main.go -c config.json -p 8080
+
+image: build
+	mkdir -p image
+	cp $(IMAGE_SRC) $(IMAGE_OUT)
+	@echo "Image: $(IMAGE_OUT) ($$(du -h $(IMAGE_OUT) | cut -f1))"
+
+clean:
+	rm -rf image/

--- a/examples/02-ops-hello-dd/config.json
+++ b/examples/02-ops-hello-dd/config.json
@@ -1,0 +1,12 @@
+{
+  "Uefi": true,
+  "CloudConfig": {
+    "Platform": "hetzner",
+    "ImageName": "ops-hello-dd",
+    "Zone": "fsn1"
+  },
+  "RunConfig": {
+    "ImageName": "ops-hello-dd",
+    "Ports": ["8080"]
+  }
+}

--- a/examples/02-ops-hello-dd/main.go
+++ b/examples/02-ops-hello-dd/main.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func main() {
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "Hello World from Nanos Unikernel!")
+	})
+	fmt.Println("Listening on :8080")
+	http.ListenAndServe(":8080", nil)
+}


### PR DESCRIPTION
Closes #2

## Summary

Adds Hello World example programs and supporting build/tooling infrastructure for building and deploying unikernels on Hetzner Cloud VMs with OPS.

### Examples
- **00-kraft-nginx-qemu** — Unikraft nginx unikernel in QEMU via cloud-init (apt-installed kraftkit, iptables port redirect)
- **00-ops-nginx-qemu** — OPS nginx unikernel in QEMU via cloud-init (automatic ops installation, port 8080 → 80)
- **01-ops-hello-http** — Minimal Go HTTP server (:8080) built with OPS, deployed via dd to Hetzner VM disk
- **02-ops-hello-dd** — Minimal Go binary deployed via OPS dd workflow (build → scp → dd to /dev/sda)

### Build system (Makefile)
- Shared server lifecycle: create-or-rebuild pattern with hcloud
- Prerequisite checks (hcloud ≥ 1.62, HCLOUD_TOKEN, ops binary)
- Per-example targets: build, deploy, destroy, ip, ssh
- Cloud-init examples rebuild with cloud-init; dd examples rebuild to vanilla Ubuntu first

### Other changes
- README updated with examples table and quick-start instructions
- .gitignore updated for OPS artifacts and build outputs