### PR TITLE
fix: harden .gitignore and document signed-commit workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,16 @@
 *.img
 .ops/
 
+# Unikraft build artifacts (kraft output, make -O dirs, staged sources)
+.build-*/
+.unikraft/
+image/
+**/.config.*
+
+# Compiled Go binaries — sources only, never commit build output
+examples/*/hello-http
+examples/*/hello-dd
+
 # OS files
-.DS_Store.ssh/
+.DS_Store
 .ssh/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+# Contributing
+
+## Commits must be signed
+
+Every commit on `main` carries an SSH signature. GitHub displays them as "Verified" on the PR page — that's what reviewers look for before merging.
+
+Signing is already configured globally on the author's machine (`user.signingkey`, `gpg.format=ssh`, `commit.gpgsign=true`). If you clone this repo and `git log --pretty='%G? %s' -1` shows `N` (no signature) on a commit you just made, your repo-local `.git/config` probably has `commit.gpgsign=false` overriding global. Fix with:
+
+```bash
+git config --local --unset commit.gpgsign
+```
+
+Then amend or redo the commit — signing happens at commit time, not push time.
+
+The SSH signing key used for `@BrainbugCloud` commits here is `~/.ssh/brainbug_hetzner`. The public half is registered under *Settings → SSH and GPG keys → Signing keys* on the author's GitHub account.
+
+## What not to commit
+
+The `.gitignore` already excludes these, but worth calling out:
+
+- **OPS build artifacts** — `*.img`, `.ops/`.
+- **Unikraft build output** — `.build-*/`, `.unikraft/`, `image/`, `.config.*` (kconfig drops).
+- **Compiled Go binaries** — `examples/*/hello-http`, `examples/*/hello-dd`. The source is in `main.go`; `ops build` produces the binary.
+
+If `git status` ever shows one of these staged, `git rm --cached` it and check your `.gitignore` hasn't been truncated.


### PR DESCRIPTION
Closes #7. Refs #6.

## Context

Commit [`435a818`](https://github.com/BrainbugCloud/hetzner-unikernels/commit/435a818) on the `feat/unikraft-images-final` branch accidentally committed ~1974 Unikraft build artifacts (`.build-*/`, `.unikraft/`) and two 7MB Go binaries (`hello-http`, `hello-dd`). That branch was never merged, so `main` stays clean — but there was nothing in `.gitignore` preventing the same mistake from happening again.

The commit was also unsigned. The repo-local `.git/config` had `commit.gpgsign=false` overriding the global `commit.gpgsign=true`, and nothing in the repo told the next contributor how to avoid that.

## What this PR does

Two commits, both small:

1. **`chore: harden .gitignore`** — adds patterns for Unikraft build output (`.build-*/`, `.unikraft/`, `image/`, `**/.config.*`) and the OPS-built Go binaries (`examples/*/hello-http`, `examples/*/hello-dd`). Also fixes a typo on the old `.ssh` pattern (`.DS_Store.ssh/` was one line by accident).
2. **`docs: add CONTRIBUTING.md`** — one page explaining the SSH-signed-commit workflow, the `git config --local --unset commit.gpgsign` fix for the gotcha that silently un-signs commits, and a short list of what not to commit.

## Verification

- [x] No new tracked file > 100 KB: `git ls-files | xargs -I{} wc -c < "{}" | sort -n | tail -3` stays within normal limits.
- [x] Both commits on this branch are signed: `git log --pretty='%h %G? %s' -2` shows `G` for both.
- [x] `make check` still passes (no Makefile changes).

## Follow-ups

This is the first of four focused PRs:
- **PR #2** (#8): modular Makefile, git submodules for Unikraft sources, defconfigs folder, rename `01-unikraft-console` → `03-unikraft-console`.
- **PR #3** (#9): per-folder READMEs and landing-page rewrite.
- **PR #4** (#10): weekly CI that deploys each example end-to-end on a real Hetzner server.

Closing #6 happens once PR #4 lands — by then the full Unikraft VM image story is both delivered (PR #2) and verified (PR #4).