### PR TITLE
chore(deps): switch unikraft to fork with UEFI GOP console support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "third_party/unikraft"]
 	path = third_party/unikraft
-	url = https://github.com/unikraft/unikraft.git
-	branch = stable
+	url = https://github.com/BrainbugCloud/unikraft
+	branch = feat/gop-console-stable
 [submodule "third_party/lib-lwip"]
 	path = third_party/lib-lwip
 	url = https://github.com/unikraft/lib-lwip.git


### PR DESCRIPTION
## Summary

- Switch `third_party/unikraft` from upstream `unikraft/unikraft@stable` to `BrainbugCloud/unikraft@feat/gop-console-stable`
- Fork adds a GOP (Graphics Output Protocol) console driver enabling UEFI framebuffer output on Hetzner CPX instances

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)