### PR TITLE
chore: update third_party dependencies to RELEASE-0.20.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "third_party/unikraft"]
 	path = third_party/unikraft
-	url = https://github.com/unikraft/unikraft.git
-	branch = stable
+	url = https://github.com/BrainbugCloud/unikraft
+	branch = feat/gop-console-stable
 [submodule "third_party/lib-lwip"]
 	path = third_party/lib-lwip
 	url = https://github.com/unikraft/lib-lwip.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,16 +1,16 @@
 [submodule "third_party/unikraft"]
 	path = third_party/unikraft
 	url = https://github.com/BrainbugCloud/unikraft
-	branch = feat/gop-console-stable
+	branch = v0.20.0-Kiviuq/feat/gop-console
 [submodule "third_party/lib-lwip"]
 	path = third_party/lib-lwip
 	url = https://github.com/unikraft/lib-lwip.git
-	branch = stable
+	tag = RELEASE-0.20.0
 [submodule "third_party/lib-libelf"]
 	path = third_party/lib-libelf
 	url = https://github.com/unikraft/lib-libelf.git
-	branch = stable
+	tag = RELEASE-0.20.0
 [submodule "third_party/app-elfloader"]
 	path = third_party/app-elfloader
 	url = https://github.com/unikraft/app-elfloader.git
-	branch = stable
+	tag = RELEASE-0.20.0


### PR DESCRIPTION
Updates third_party submodules to use RELEASE-0.20.0 tags instead of stable branches. The stable branches were updated in release 0.21.0, but we'll move to 0.21.0 in #21. For now, we use the 0.20.0 tag for stability.