### PR TITLE
chore(deps): switch unikraft to fork with UEFI GOP console support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "third_party/unikraft"]
 	path = third_party/unikraft
-	url = https://github.com/unikraft/unikraft.git
-	branch = stable
+	url = https://github.com/BrainbugCloud/unikraft
+	branch = feat/gop-console-stable
 [submodule "third_party/lib-lwip"]
 	path = third_party/lib-lwip
 	url = https://github.com/unikraft/lib-lwip.git


### PR DESCRIPTION
Switches the unikraft submodule to a fork with UEFI GOP console support. This is the dependency needed for the Go HTTP example in #20.