### PR TITLE
examples/{03,04}: split run-{grub,efi} into Hetzner-close and -simple

### DIFF
--- a/examples/03-unikraft-console/Makefile
+++ b/examples/03-unikraft-console/Makefile
@@ -47,7 +47,8 @@ OVMF_VARS  ?= /usr/share/OVMF/OVMF_VARS_4M.fd
 
 .PHONY: build run use-branch deploy \
         build-kernel-grub build-kernel-efi \
-        disk-grub disk-efi run-grub run-efi \
+        disk-grub disk-efi \
+        run-grub run-grub-simple run-efi run-efi-simple \
         deploy-grub deploy-efi clean
 
 # ── Default deploy target (dispatched to by top-level `make 03-...`) ───
@@ -135,8 +136,27 @@ disk-efi: $(KERNEL_EFI) $(INITRD)
 	@echo "EFI disk: $(EFI_IMG) ($$(du -h $(EFI_IMG) | cut -f1))"
 
 # ── Local QEMU tests ───────────────────────────────────────────────────
+#
+# Two flavours per boot protocol — see examples/04-unikraft-go-http/Makefile
+# for the full rationale. Short version:
+#
+#   run-{grub,efi}         Approximates Hetzner cx23 / cpx22.
+#   run-{grub,efi}-simple  Minimum config the unikernel needs to boot.
+#
+# Both flavours run under TCG as long as the kernel uses the default
+# CONFIG_UKPLAT_CPU_MAXCOUNT=1.
 
+# ── cx23-close (multiboot/SeaBIOS) ──
 run-grub: disk-grub
+	qemu-system-x86_64 \
+	  -machine pc-q35-7.2 \
+	  -cpu Skylake-Server-v3 \
+	  -smp 2 -m 4G -no-reboot \
+	  -device virtio-net-pci,netdev=net0 -netdev user,id=net0 \
+	  -display none -serial stdio \
+	  -cdrom $(GRUB_IMG)
+
+run-grub-simple: disk-grub
 	qemu-system-x86_64 \
 	  -machine pc -cpu qemu64,+pdpe1gb,+rdrand,+rdseed \
 	  -m 128M -no-reboot \
@@ -144,7 +164,21 @@ run-grub: disk-grub
 	  -display none -serial stdio \
 	  -cdrom $(GRUB_IMG)
 
+# ── cpx22-close (EFI stub) ──
 run-efi: disk-efi
+	@cp $(OVMF_VARS) image/ovmf-vars.fd
+	qemu-system-x86_64 \
+	  -machine pc-q35-7.2,smm=off \
+	  -cpu EPYC-Genoa \
+	  -smp 2 -m 4G -no-reboot \
+	  -drive if=pflash,format=raw,readonly=on,file=$(OVMF_CODE) \
+	  -drive if=pflash,format=raw,file=image/ovmf-vars.fd \
+	  -drive file=$(EFI_IMG),if=none,id=hd0,format=raw \
+	  -device virtio-blk-pci,drive=hd0,bootindex=1 \
+	  -device virtio-net-pci,netdev=net0 -netdev user,id=net0 \
+	  -display none -serial stdio
+
+run-efi-simple: disk-efi
 	@cp $(OVMF_VARS) image/ovmf-vars.fd
 	qemu-system-x86_64 \
 	  -machine pc-i440fx-7.0,smm=off \

--- a/examples/04-unikraft-go-http/Makefile
+++ b/examples/04-unikraft-go-http/Makefile
@@ -175,6 +175,12 @@ run-grub-simple: disk-grub
 # virtio-scsi the real cpx22 uses — Unikraft has neither block driver, so
 # the choice doesn't affect the unikernel; the EFI stub reads the kernel
 # off the disk before ExitBootServices and we never touch it again.
+#
+# virtio devices are placed behind explicit pcie-root-ports to mirror the
+# real cpx22 PCIe topology (devices live on secondary buses, not pcie.0
+# directly). This exercises Unikraft's PCIe bridge scan + 64-bit BAR
+# mapping path in driver/ukbus/pci — the same path that fails on real
+# Hetzner without the v0.21 PCIe bridge scanning fix.
 run-efi: disk-efi
 	@cp $(OVMF_VARS) image/ovmf-vars.fd
 	qemu-system-x86_64 \
@@ -184,8 +190,11 @@ run-efi: disk-efi
 	  -drive if=pflash,format=raw,readonly=on,file=$(OVMF_CODE) \
 	  -drive if=pflash,format=raw,file=image/ovmf-vars.fd \
 	  -drive file=$(EFI_IMG),if=none,id=hd0,format=raw \
-	  -device virtio-blk-pci,drive=hd0,bootindex=1 \
-	  -device virtio-net-pci,netdev=net0 -netdev user,id=net0,hostfwd=tcp::8080-:8080 \
+	  -device pcie-root-port,id=rp0,chassis=1,slot=0,bus=pcie.0 \
+	  -device pcie-root-port,id=rp1,chassis=2,slot=1,bus=pcie.0 \
+	  -device virtio-blk-pci,bus=rp0,drive=hd0,bootindex=1 \
+	  -device virtio-net-pci,bus=rp1,netdev=net0 \
+	  -netdev user,id=net0,hostfwd=tcp::8080-:8080 \
 	  -display none -serial stdio
 
 run-efi-simple: disk-efi

--- a/examples/04-unikraft-go-http/Makefile
+++ b/examples/04-unikraft-go-http/Makefile
@@ -52,7 +52,8 @@ OVMF_VARS  ?= /usr/share/OVMF/OVMF_VARS_4M.fd
 
 .PHONY: build run deploy \
         build-kernel-grub build-kernel-efi \
-        disk-grub disk-efi run-grub run-efi \
+        disk-grub disk-efi \
+        run-grub run-grub-simple run-efi run-efi-simple \
         deploy-grub deploy-efi clean
 
 # ── Default deploy target ──────────────────────────────────────────────
@@ -130,8 +131,37 @@ disk-efi: $(KERNEL_EFI) $(INITRD)
 	@echo "EFI disk: $(EFI_IMG) ($$(du -h $(EFI_IMG) | cut -f1))"
 
 # ── Local QEMU tests ───────────────────────────────────────────────────
+#
+# Two flavours per boot protocol:
+#
+#   run-{grub,efi}         Approximates the real Hetzner VM (cx23 / cpx22)
+#                          — q35 chipset, the actual host CPU model, 2 vCPUs,
+#                          4 GB RAM. Uses TCG warnings to flag features
+#                          the host CPU exposes but TCG can't emulate (those
+#                          bits are silently masked from the guest).
+#   run-{grub,efi}-simple  Minimum config the unikernel needs to boot
+#                          (1 GiB pages, RDRAND/RDSEED). Fast startup, useful
+#                          for iterating on the kernel itself without paying
+#                          for the larger memory + chipset emulation.
+#
+# Both flavours run under TCG (no /dev/kvm) as long as the kernel is built
+# with CONFIG_UKPLAT_CPU_MAXCOUNT=1 (the default). MAXCOUNT > 1 enables
+# CONFIG_HAVE_SMP, whose APIC bringup path UD2's under TCG.
 
+# ── cx23-close (multiboot/SeaBIOS) ──
+# cx23 is Intel Skylake (family 6 model 85), q35 chipset, BIOS firmware,
+# 2 vCPUs, 4 GB. The unikernel doesn't enumerate ACPI on the multiboot path,
+# so SMP and APIC differences vs the simple flavour don't change behaviour.
 run-grub: disk-grub
+	qemu-system-x86_64 \
+	  -machine pc-q35-7.2 \
+	  -cpu Skylake-Server-v3 \
+	  -smp 2 -m 4G -no-reboot \
+	  -device virtio-net-pci,netdev=net0 -netdev user,id=net0,hostfwd=tcp::8080-:8080 \
+	  -display none -serial stdio \
+	  -cdrom $(GRUB_IMG)
+
+run-grub-simple: disk-grub
 	qemu-system-x86_64 \
 	  -machine pc -cpu qemu64,+pdpe1gb,+rdrand,+rdseed \
 	  -m 256M -no-reboot \
@@ -139,7 +169,26 @@ run-grub: disk-grub
 	  -display none -serial stdio \
 	  -cdrom $(GRUB_IMG)
 
+# ── cpx22-close (EFI stub) ──
+# cpx22 is AMD EPYC-Genoa (Zen 4), q35 chipset, UEFI firmware (EDK II from
+# Hetzner), 2 vCPUs, 4 GB. The disk is virtio-blk here rather than the
+# virtio-scsi the real cpx22 uses — Unikraft has neither block driver, so
+# the choice doesn't affect the unikernel; the EFI stub reads the kernel
+# off the disk before ExitBootServices and we never touch it again.
 run-efi: disk-efi
+	@cp $(OVMF_VARS) image/ovmf-vars.fd
+	qemu-system-x86_64 \
+	  -machine pc-q35-7.2,smm=off \
+	  -cpu EPYC-Genoa \
+	  -smp 2 -m 4G -no-reboot \
+	  -drive if=pflash,format=raw,readonly=on,file=$(OVMF_CODE) \
+	  -drive if=pflash,format=raw,file=image/ovmf-vars.fd \
+	  -drive file=$(EFI_IMG),if=none,id=hd0,format=raw \
+	  -device virtio-blk-pci,drive=hd0,bootindex=1 \
+	  -device virtio-net-pci,netdev=net0 -netdev user,id=net0,hostfwd=tcp::8080-:8080 \
+	  -display none -serial stdio
+
+run-efi-simple: disk-efi
 	@cp $(OVMF_VARS) image/ovmf-vars.fd
 	qemu-system-x86_64 \
 	  -machine pc-i440fx-7.0,smm=off \


### PR DESCRIPTION
## Summary

- Split `run-grub` / `run-efi` into a Hetzner-shape-matching flavour and a minimum-config `-simple` flavour, per the request in #32.
- Picked CPU models, chipset and resource sizing from probe Hetzner VMs (one cpx22, one cx23) created and destroyed during this work.
- **Wire example 04's `run-efi` virtio devices behind explicit `pcie-root-port` bridges** so the close flavour exercises Unikraft's PCIe bridge scan + 64-bit BAR mapping path — and surfaces a latent crash in the modern-virtio init that wouldn't otherwise reproduce locally.

> **Rebased onto `chore/v0.21.0`** after the v0.21.0-Ijiraq-Hetzner submodule was rebuilt (parent repo commit `e8bb183`). The original `examples/04: align EFI defconfig with v0.21` pre-req is gone — its content is already on `chore/v0.21.0`, so git auto-dropped it during the rebase.

## What's in each flavour

| Target              | Machine         | CPU                  | vCPUs | RAM    | Boot    | PCI topology                          | Approximates |
|---------------------|-----------------|----------------------|-------|--------|---------|---------------------------------------|--------------|
| `run-grub`          | `pc-q35-7.2`    | `Skylake-Server-v3`  | 2     | 4 GB   | SeaBIOS | virtio-net on `pcie.0`                | Hetzner cx23 |
| `run-grub-simple`   | `pc`            | `qemu64,+pdpe1gb,+rdrand,+rdseed` | 1 | 256 / 128 MB | SeaBIOS | flat PCI                              | minimum unikernel needs |
| `run-efi`           | `pc-q35-7.2`    | `EPYC-Genoa`         | 2     | 4 GB   | OVMF    | **virtio-blk + virtio-net behind two `pcie-root-port`s** | Hetzner cpx22 |
| `run-efi-simple`    | `pc-i440fx-7.0` | `qemu64,+x2apic,+pdpe1gb,+rdrand,+rdseed` | 1 | 256 / 128 MB | OVMF | flat PCI (IDE disk)                   | minimum unikernel needs |

The `-close` variants emit TCG warnings for CPU features the host CPU *exposes* but TCG can't emulate (avx512\*, ibrs, etc.) — those bits are silently masked from the guest, which is fine because Unikraft doesn't use them.

## Where the numbers came from

A probe cpx22 + cx23 in nbg1 (created and destroyed during this work) reported:

- **cpx22**: AMD EPYC-Genoa (family 25 model 17), 2 vCPUs, 3.9 GB usable, Hetzner UEFI 20171111, q35 chipset (82G33 + ICH9), virtio-blk/scsi storage, virtio-net 1.0.
- **cx23**: Intel Xeon Skylake-Server-v3 (no TSX, IBRS), 2 vCPUs, 4 GB, q35 chipset, SeaBIOS, virtio-net 1.0.

Both VMs use **q35** even though they look like classic-PC at first glance. The original `run-*` targets used `pc` / `pc-i440fx-7.0`; switching to q35 is the biggest single fidelity bump.

The disk path in `run-efi` is virtio-blk rather than the virtio-scsi the real cpx22 uses — Unikraft has neither block driver compiled in, so the choice doesn't affect the unikernel; the EFI stub reads the kernel off disk before `ExitBootServices` and we never touch storage again.

## PCIe-root-port topology in `run-efi` (cpx22-close)

Real cpx22 sits virtio-blk and virtio-net on **secondary buses behind PCIe root ports**, not directly on `pcie.0`. The QEMU command line now mirrors that:

```
-device pcie-root-port,id=rp0,chassis=1,slot=0,bus=pcie.0
-device pcie-root-port,id=rp1,chassis=2,slot=1,bus=pcie.0
-device virtio-blk-pci,bus=rp0,drive=hd0,bootindex=1
-device virtio-net-pci,bus=rp1,netdev=net0
```

EFI firmware traverses the bridge fine (`PciRoot(0x0)/Pci(0x2,0x0)/Pci(0x0,0x0)`) and Unikraft's bridge scanner (the path covered by submodule commit `77a6be7c "pci: fix PCIe bridge scanning and 64-bit BAR mapping"`) finds the device on bus 1. But the modern-virtio init path then crashes:

```
ERR  [libvirtio_bus]  Failed to find the driver for the virtio device 0x400030020 (id:2)
ERR  [libvirtio_pci]  Failed to register the virtio device: -14
ERR  [libukbus_pci]   PCI 01:00.00: Failed to initialize device driver
CRIT Unikraft Crash - Ijiraq (0.21.0~7c672033)
  rip = 0x185f56 → virtio_pci_modern_add_dev at virtio_pci.c:905
```

`run-efi-simple` is unaffected — it uses i440fx + flat PCI + IDE disk, so the bridge-scan + modern-virtio path never runs. **The `-close` flavour now functions as a local regression test for the Hetzner-shaped PCIe topology**: the same crash signature is what would otherwise only surface against a real cpx22.

## Caveats

- **TCG ⊕ MAXCOUNT > 1**: Both `-close` flavours run fine under TCG (no `/dev/kvm`) **as long as the kernel uses `CONFIG_UKPLAT_CPU_MAXCOUNT=1`** (the default). Bumping it enables `CONFIG_HAVE_SMP`, whose APIC bringup `ud2`'s under TCG. This means PR #31 (the MAXCOUNT=2 workaround) and this PR are mutually exclusive for local TCG testing — `run-efi` won't boot locally with both applied. With the upstream MADT fix already in our submodule (`eb409e60` → carried through `e8bb183` rebuild), MAXCOUNT=1 is safe on the real cpx22 too, so #31 is no longer required.
- The simple variants are byte-for-byte the previous `run-grub` / `run-efi`, just renamed. Anyone with `make run-efi` muscle memory who needs the small/fast version should switch to `make run-efi-simple`.

## Test plan

- [x] `make run-grub-simple` — boots to `Listening on :8080…`
- [x] `make run-grub` — boots to `Listening on :8080…`
- [x] `make run-efi-simple` — boots to `Listening on :8080…`
- [x] `make run-efi` — **crashes** in `virtio_pci_modern_add_dev` (intentional: reproduces the cpx22 PCIe-bridge / modern-virtio failure mode locally; `run-efi-simple` is the green path for now)
- [x] Example 03 `make deploy-efi` against real Hetzner cpx22 — Hello World on VNC, confirmed by reporter
- [ ] Example 04 `make deploy-efi` against real Hetzner cpx22 — expected to reproduce the same crash; pending

## Commits

1. `examples/{03,04}: split run-{grub,efi} into hetzner-close and -simple` — the original split work
2. `examples/04: place virtio devices behind pcie-root-ports in run-efi` — Hetzner-shaped PCI topology, surfaces the modern-virtio crash locally

Closes #32.
